### PR TITLE
Add support for input of ocean vertical levels to specifier class.

### DIFF
--- a/examples/control_ocn_series.py
+++ b/examples/control_ocn_series.py
@@ -21,6 +21,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 clobber = True
 suffix = 'nc'
@@ -46,6 +47,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
+
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/examples/control_ocn_slice.py
+++ b/examples/control_ocn_slice.py
@@ -21,6 +21,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 suffix = 'nc'
 clobber = True
@@ -46,7 +47,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
 
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/pyaverager/climAverager.py
+++ b/pyaverager/climAverager.py
@@ -317,7 +317,7 @@ def weighted_avg_var_missing(var,years,hist_dict,ave_info,file_dict,ave_type,fil
     return var_Ave
 
 
-def weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict):
+def weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict,nlev):
 
     '''
     Computes the weighted hor mean rms diff for a year  
@@ -336,6 +336,8 @@ def weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist
 
     @param hist_dict   A dictionary that holds file references for all years/months. 
 
+    @param nlev        Number of ocean vertical levels
+
     @param ave_info    A dictionary of the type of average that is to be done.
                        Includes:  type, months_to_average, fn, and weights
                        (weights are not used in this function/average)
@@ -344,6 +346,7 @@ def weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist
                        are needed by this average calculation.
 
     @return var_Ave    The averaged results for this variable across the designated time frame.
+
     '''
 
     # Get correct data slice from the yearly average file
@@ -357,7 +360,7 @@ def weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist
     region_mask = MA.expand_dims(slev_mask, axis=0)
     weights = MA.expand_dims(slev_weights, axis=0)
     if var_val.ndim > 2:
-        for lev in range(1,60):
+        for lev in range(1,nlev):
             new_region_mask = MA.expand_dims(slev_mask, axis=0)
             region_mask = np.vstack((region_mask,new_region_mask))
             new_weights = MA.expand_dims(slev_weights, axis=0)
@@ -404,7 +407,7 @@ def diff_var(var, avg_test_slice, obs_file):
 
     return var_Avg_diff
 
-def weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict,avg_test_slice,obs_file):
+def weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict,avg_test_slice,obs_file,nlev):
 
     '''
     Computes the weighted rms for a year  
@@ -434,6 +437,8 @@ def weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dic
  
     @param obs_file       Observation file that contains the values to be used in the caluculation.
 
+    @param nlev           Number of ocean vertical levels
+
     @return nrms          The normalized rms results for this variable.
     '''
 
@@ -448,7 +453,7 @@ def weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dic
     # Since weights and region mask are only one level, we need to expand them to all levels
     region_mask = MA.expand_dims(slev_mask, axis=0)
     weights = MA.expand_dims(slev_weights, axis=0)
-    for lev in range(1,60):
+    for lev in range(1,nlev):
         new_region_mask = MA.expand_dims(slev_mask, axis=0)
         region_mask = np.vstack((region_mask,new_region_mask))
         new_weights = MA.expand_dims(slev_weights, axis=0)
@@ -474,7 +479,7 @@ def weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dic
 
     return nrms
 
-def mean_diff_rms(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict,obs_file,reg_obs_file,simplecomm,serial,MPI_TAG,AVE_TAG):
+def mean_diff_rms(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,file_dict,obs_file,reg_obs_file,simplecomm,serial,MPI_TAG,AVE_TAG,nlev):
 
     '''
     Computes the weighted hor mean rms diff for a year  
@@ -510,6 +515,8 @@ def mean_diff_rms(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,
 
     @MPI_TAG             Integer tag used to communicate message numbers.
 
+    @param nlev          Number of ocean vertical levels
+
     @return var_Ave      The averaged results for this variable.
 
     @return var_DIFF     The difference results for this variable.
@@ -523,7 +530,7 @@ def mean_diff_rms(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,
     var_rms = var+'_RMS'
 
     ## Get the masked regional average
-    var_Avg = weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year[0],hist_dict,ave_info,file_dict)
+    var_Avg = weighted_hor_avg_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year[0],hist_dict,ave_info,file_dict,nlev)
     ## Send var_Avg results to local root to write
     if (not serial):
         #md_message_v = {'name':var,'shape':var_Avg.shape,'dtype':var_Avg.dtype,'average':var_Avg}
@@ -541,7 +548,7 @@ def mean_diff_rms(var,reg_name,reg_num,mask_var,wgt_var,year,hist_dict,ave_info,
     ## Get the RMS from the obs diff
     var_slice = rover.fetch_slice(hist_dict,year[0],0,var,file_dict)
     temp_diff = diff_var(var, var_slice, obs_file)
-    var_RMS = weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year[0],hist_dict,ave_info,file_dict,temp_diff,obs_file)
+    var_RMS = weighted_rms_var_from_yr(var,reg_name,reg_num,mask_var,wgt_var,year[0],hist_dict,ave_info,file_dict,temp_diff,obs_file,nlev)
     ## Send var_RMS results to local root to write
     if (not serial):
         #md_message = {'name':var_rms,'shape':var_RMS.shape,'dtype':var_RMS.dtype,'average':var_RMS}

--- a/pyaverager/specification.py
+++ b/pyaverager/specification.py
@@ -83,7 +83,8 @@ class pyAveragerSpecifier(Specifier):
                ncl_location='null',
                year0=-99,
                year1=-99,
-               collapse_dim=''):
+               collapse_dim='',
+               vertical_levels=60):
     '''
     Initializes the internal data with optional arguments
 
@@ -153,6 +154,8 @@ class pyAveragerSpecifier(Specifier):
     @param year1            The last year - only used to create the cice pre_proc file. 
 
     @param collapse_dims    Used to collapse/average over one dim.
+
+    @param vertical_levels  Number of ocean vertical levels
     '''
 
     # Where the input is located
@@ -266,3 +269,6 @@ class pyAveragerSpecifier(Specifier):
 
     # Used to collapse/average over one dim.
     self.collapse_dim = collapse_dim
+
+    # Used to specify the number of ocean vertical levels
+    self.vertical_levels = vertical_levels

--- a/testing/default_tests/control_ocn_series.py
+++ b/testing/default_tests/control_ocn_series.py
@@ -6,8 +6,7 @@ import os
 #### User modify ####
 
 in_dir='/glade/p/tdd/asap/data/b.e12.B1850C5CN.ne30_g16.init.ch.027/ocn/mon/tseries/'
-##out_dir= os.environ.get('RESULTS_DIR')+'/ocn/series/'
-out_dir= '/glade/scratch/aliceb/b.e12.B1850C5CN.ne30_g16.init.ch.027/ocn/series/'
+out_dir= os.environ.get('RESULTS_DIR')+'/ocn/series/'
 pref= 'b.e12.B1850C5CN.ne30_g16.init.ch.027.pop.h'
 htype= 'series'
 average = ['tavg:1:10','mavg:1:10','moc:1:10','mocm:1:10','hor.meanConcat:1:10']

--- a/testing/default_tests/control_ocn_series.py
+++ b/testing/default_tests/control_ocn_series.py
@@ -6,7 +6,8 @@ import os
 #### User modify ####
 
 in_dir='/glade/p/tdd/asap/data/b.e12.B1850C5CN.ne30_g16.init.ch.027/ocn/mon/tseries/'
-out_dir= os.environ.get('RESULTS_DIR')+'/ocn/series/'
+##out_dir= os.environ.get('RESULTS_DIR')+'/ocn/series/'
+out_dir= '/glade/scratch/aliceb/b.e12.B1850C5CN.ne30_g16.init.ch.027/ocn/series/'
 pref= 'b.e12.B1850C5CN.ne30_g16.init.ch.027.pop.h'
 htype= 'series'
 average = ['tavg:1:10','mavg:1:10','moc:1:10','mocm:1:10','hor.meanConcat:1:10']
@@ -22,6 +23,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 clobber = True
 suffix = 'nc'
@@ -47,6 +49,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
+
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/testing/default_tests/control_ocn_slice.py
+++ b/testing/default_tests/control_ocn_slice.py
@@ -22,6 +22,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 suffix = 'nc'
 clobber = True
@@ -47,7 +48,7 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
-
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/testing/noDepend_tests/control_ocn_series.py
+++ b/testing/noDepend_tests/control_ocn_series.py
@@ -22,6 +22,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 clobber = True
 suffix = 'nc'
@@ -47,6 +48,7 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/testing/noDepend_tests/control_ocn_slice.py
+++ b/testing/noDepend_tests/control_ocn_slice.py
@@ -22,6 +22,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 suffix = 'nc'
 clobber = True
@@ -47,7 +48,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
 
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/testing/serial_tests/control_ocn_series.py
+++ b/testing/serial_tests/control_ocn_series.py
@@ -22,6 +22,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 clobber = True
 suffix = 'nc'
@@ -47,6 +48,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
+
 PyAverager.run_pyAverager(pyAveSpecifier)
 

--- a/testing/serial_tests/control_ocn_slice.py
+++ b/testing/serial_tests/control_ocn_slice.py
@@ -22,6 +22,7 @@ region_wgt_var = 'TAREA'
 obs_dir = '/glade/p/work/mickelso/PyAvg-OMWG-obs/obs/'
 obs_file = 'obs.nc'
 reg_obs_file_suffix = '_hor_mean_obs.nc'
+vertical_levels = 60
 
 suffix = 'nc'
 clobber = True
@@ -47,7 +48,8 @@ pyAveSpecifier = specification.create_specifier(in_directory=in_dir,
                                   region_wgt_var=region_wgt_var,
                                   obs_dir=obs_dir,
                                   obs_file=obs_file,
-                                  reg_obs_file_suffix=reg_obs_file_suffix)
+                                  reg_obs_file_suffix=reg_obs_file_suffix,
+                                  vertical_levels=vertical_levels)
 
 PyAverager.run_pyAverager(pyAveSpecifier)
 


### PR DESCRIPTION
Test suite: tested with default_tests/control_ocn_series.py.

Fixes [Github issue #]: N/A

User interface changes: add vertical_level parameter to specification class

Input data changes: None

Code review: