### PR TITLE
move PreProc.py read_obs functionality into create_pre_proc

### DIFF
--- a/pyaverager/PreProc.py
+++ b/pyaverager/PreProc.py
@@ -18,34 +18,6 @@ class PreProc(object):
         self.create_pre_proc(spec)
 
 
-    def read_obs(self,obs_file,tarea,tlong,tlat):
-
-        '''
-        Read in the ice observation file to get area, lat, and lon values.
-    
-        @param obs_file   The observation file to pull values from.
-
-        @param tarea      The variable name for tarea.
-
-        @param tlong      The variable name for tlong.
-
-        @param tlat       The vaiable name for tlat.
-
-        @return lat       A pointer to lat.
-
-        @return lon       A pointer to lon.
-
-        @reutrn area      The values for area.
-
-        '''
-        
-	file_hndl = Nio.open_file(obs_file,'r')
-	lat = file_hndl.variables[tlat]
-	lon = file_hndl.variables[tlong]
-	area = file_hndl.variables[tarea]
-        area = area[:]*1.0e-4     
-	return lat,lon,area
-
     def read_reg_mask(self,reg_file,reg_name):
 
         '''
@@ -197,7 +169,13 @@ class PreProc(object):
                 tarea = 'TAREA'
                 tlong = 'TLONG'
                 tlat = 'TLAT'
-                o_lat,o_lon,o_area = self.read_obs(obs_file,tarea,tlong,tlat)
+
+                # Read in the ice observation file to get area, lat, and lon values.
+                obs_file_hndl = Nio.open_file(obs_file,'r')
+                o_lat = obs_file_hndl.variables[tlat]
+                o_lon = obs_file_hndl.variables[tlong]
+                o_area = obs_file_hndl.variables[tarea]
+                o_area = o_area[:]*1.0e-4
 
 		# If using time series files, open the variable's file now
 		if (spec.hist_type == 'series'):


### PR DESCRIPTION
The new PyNIO v1.5.3 on cheyenne and DAV closes open Nio files implicitly now by default when
leaving the scope of a function. This PR moves the functionality in the PreProc read_obs function
to be directly in-line in the create_pre_proc so the obs file is not prematurely closed. 

The read_obs function was only called once by the pyAverager in the PreProc.py class. 

Tested with 5 years of CICE data both in serial and parallel using the new ncar_pylib -c 20180705 virtualenv. 