### PR TITLE
make rover be able to handle mom6 files

### DIFF
--- a/pyaverager/rover.py
+++ b/pyaverager/rover.py
@@ -363,7 +363,10 @@ def set_slices_and_vars_time_slice(directory, file_pattern, prefix, suffix, star
             #file_prefix = directory+"/"+prefix
             yrS = str(yr)
             mS = str(m)
-            stamp = yrS.zfill(4)+"-"+mS.zfill(2)
+            if ".mom6." in prefix:
+                stamp = yrS.zfill(4)+"_"+mS.zfill(2)
+            else:
+                stamp = yrS.zfill(4)+"-"+mS.zfill(2)
             filename,file_prefix = get_slice_fn(file_pattern, directory, prefix, suffix, stamp)
             filename = directory+"/"+filename
             if (os.path.isfile(filename)):
@@ -379,7 +382,10 @@ def set_slices_and_vars_time_slice(directory, file_pattern, prefix, suffix, star
     # Grab variable list from a file.
     yrS = str(start_yr).zfill(4)
     #test_file = directory+"/"+prefix+"."+yrS+"-01.nc" 
-    stamp = yrS+"-01"
+    if ".mom6." in prefix:
+        stamp = yrS+"_01"
+    else:
+        stamp = yrS+"-01"
     test_file,file_prefix = get_slice_fn(file_pattern, directory, prefix, suffix, stamp)
     test_file = directory+'/'+test_file
     f = Nio.open_file(test_file,"r")


### PR DESCRIPTION
MOM6 has a slightly different (and fixed) file naming convention thanks to the FMS library it relies on. The change in this PR makes pyaverager be able to handle mom6 files. @sherimickelson feel free to reject this PR if there is a better alternative to achieve this.